### PR TITLE
Fix file descriptor leak on connection failure

### DIFF
--- a/src/TCP/connection.cpp
+++ b/src/TCP/connection.cpp
@@ -204,8 +204,10 @@ Connection Connection::with(std::string addr, int port) {
     server.sin_port   = ::htons(port);
     server.sin_addr   = {inet_addr(addr.c_str())};
 
-    if (::connect(sock, reinterpret_cast<struct sockaddr *>(&server), sizeof(server)) < 0)
+    if (::connect(sock, reinterpret_cast<struct sockaddr *>(&server), sizeof(server)) < 0) {
+        ::close(sock);
         throw std::runtime_error("Cannot connect, errno = " + std::to_string(errno));
+    }
 
     return Connection(sock);
 }


### PR DESCRIPTION
When ::connect() fails, the socket file descriptor was not closed before throwing an exception, leading to a file descriptor leak. This fix ensures the socket is properly closed on connection failure.

We had code that was retrying opening a modbus connection  on an interval. When there was no device available, it would fail and create a new file descriptor every time. I tested this change and confirmed the leak resolved.